### PR TITLE
Fix: Corrected typo from 'bt()' to 't()' Twig filter

### DIFF
--- a/src/templates/_includes/macros.twig
+++ b/src/templates/_includes/macros.twig
@@ -11,7 +11,7 @@
 
 {% macro configWarning(setting) %}
     {% set setting = '<code>'~setting~'</code>' %}
-    {{ "This setting is being overridden by {setting} in the {file} config file."|bt({
+    {{ "This setting is being overridden by {setting} in the {file} config file."|t('slugsmith', {
         setting: setting,
         file: '<code>slugsmith.php</code>'
     })|raw }}


### PR DESCRIPTION
Fixes issue #1.